### PR TITLE
Update README and POM for installation instructions and SCM details; enhance .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,29 @@
-# IntelliJ IDEA
-.idea/
-*.iws
-*.iml
-*.ipr
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+/.idea/
+/.java-version
 
 # Maven
 target/
@@ -12,6 +33,19 @@ pom.xml.versionsBackup
 pom.xml.next
 release.properties
 dependency-reduced-pom.xml
+
+
+### Mule Connectors ###
+automation-credentials.properties
+
+# IntelliJ IDEA
+.idea/
+*.iws
+*.iml
+*.ipr
+
+# VSCode
+.vscode
 
 # MuleSoft
 .mule/
@@ -24,20 +58,16 @@ exchange-docs/
 
 # OS-specific files
 .DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store
 Thumbs.db
-
-# Compiled class files
-*.class
 
 # Generated files
 generated-sources/
 generated-test-sources/
 
-### Mule Connectors ###
-automation-credentials.properties
-
 # Configuration files
-/.vscode/
 .vscode/
 .classpath
 .project
@@ -46,7 +76,7 @@ automation-credentials.properties
 # Miscellaneous
 *.bak
 *.tmp
-target/
+*.sh
 
 
-/.java-version
+

--- a/README.md
+++ b/README.md
@@ -25,8 +25,46 @@ To use this connector, add the following dependency to your application's `pom.x
 	</dependency>
 ```
 
+### Installation (Open Source Version)
+
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.mulesoft-ai-chain-project/mule4-agentforce-connector)](https://central.sonatype.com/artifact/io.github.mulesoft-ai-chain-project/mule4-agentforce-connector/overview)
+
+#### Maven central dependency
+
+```xml
+    <dependency>
+       <groupId>io.github.mulesoft-ai-chain-project</groupId>
+       <artifactId>mule4-agentforce-connector</artifactId>
+       <version>{version}</version>
+       <classifier>mule-plugin</classifier>
+    </dependency>
+```
+
+#### Build and install locally
+
+To use this connector, first [build and install](https://mac-project.ai/docs/agentforce/getting-started) the connector into your local maven repository.
+Then add the following dependency to your application's `pom.xml`:
+
+```xml
+    <dependency>
+        <groupId>com.mulesoft.connectors</groupId>
+        <artifactId>mule4-agentforce-connector</artifactId>
+        <version>{version}</version>
+        <classifier>mule-plugin</classifier>
+    </dependency>
+```
+
+#### Private Anypoint Exchange
+
+You can also make this connector available as an asset in your Anypoint Exchange.
+
+This process will require you to build the connector as above, but additionally you will need
+to make some changes to the `pom.xml`.  For this reason, we recommend you fork the repository.
+
+Then, follow the MuleSoft [documentation](https://docs.mulesoft.com/exchange/to-publish-assets-maven) to modify and publish the asset.
+
 ### Documentation
-- Check out MuleChain Agentforce Connector Documentation on [mac-project.ai](https://mac-project.ai/docs/einstein-ai)
+- Check out MuleChain Agentforce Connector Documentation on [mac-project.ai](https://mac-project.ai/docs/agentforce)
 - Learn from the [Getting Started Playlist on YouTube](https://www.youtube.com/playlist?list=PLnuJGpEBF6ZAV1JfID1SRKN6OmGORvgv6)
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,13 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>Agentforce Connector</name>
+    <url>https://mac-project.ai/docs/agentforce/connector-overview</url>
+    <scm>
+        <connection>scm:git:git://github.com/MuleSoft-AI-Chain-Project/mule-agentforce-connector.git</connection>
+        <developerConnection>scm:git:ssh://github.com:MuleSoft-AI-Chain-Project/mule-agentforce-connector.git</developerConnection>
+        <url>https://github.com/MuleSoft-AI-Chain-Project/mule-agentforce-connector/tree/master</url>
+    </scm>
+
 
     <licenses>
         <license>
@@ -264,6 +271,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.6.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <checksums>all</checksums>
+                    <deploymentName>MuleSoft Agentforce Connector Mule 4 Deployment</deploymentName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -272,6 +304,10 @@
             <id>mule-releases</id>
             <name>Nexus Public Releases</name>
             <url>https://repository-master.mulesoft.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
     <pluginRepositories>


### PR DESCRIPTION
Add maven central deployment support for open source version.

- Updated pom xml with 2 new plugins: maven-gpg-plugin and central-publishing-maven-plugin
- Updated pom xml with new repository https://repo.maven.apache.org/maven2
- Updated README.md with instructions to install open source version.
- Updated .gitignore file to exclude additional files/folders

TO SKIP SIGNATURE STEP DURING BUILD USE -Dgpg.skip

`mvn clean install  -Dgpg.skip`